### PR TITLE
Add /tabs/by-id/*/active

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -344,6 +344,24 @@ router["/tabs/by-id/*/control"] = {
   },
   async truncate({path, size}) { return {}; }
 };
+router["/tabs/by-id/*/active"] = {
+  // echo true > mnt/tabs/by-id/1644/active
+  // cat mnt/tabs/by-id/1644/active
+  async read({path, fh, offset, size}) {
+    const tabId = parseInt(pathComponent(path, -2));
+    const tab = await browser.tabs.get(tabId);
+    const buf = (JSON.stringify(tab.active) + '\n').slice(offset, offset + size);
+    return { buf };
+  },
+  async write({path, buf}) {
+    if (buf.trim() === "true") {
+      const tabId = parseInt(pathComponent(path, -2));
+      await browser.tabs.update(tabId, { active: true });
+    }
+    return {size: stringToUtf8Array(buf).length};
+  },
+  async truncate({path, size}) { return {}; }
+};
 
 // debugger/ : debugger-API-dependent (Chrome-only)
 (function() {


### PR DESCRIPTION
Add route `/tabs/by-id/*/activate` to allow switching tabs with
```sh
echo true > mnt/tabs/by-id/1644/activate
```

An alternative approach would be to [add `/tabs/by-id/*/update`](https://github.com/osnr/TabFS/commit/64d0818b85d4388289e958ccc89fb302e2b9e73e) instead in order to allow passing arbitrary properties to [`tabs.update()`](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/tabs/update) like
```sh
jq -n '{active:true,highlighted:true}' > mnt/tabs/by-id/1438/update
```

(Let me know if `/update` would be more desirable than `/activate`, then I'll replace the PR.)
