### PR TITLE
Use environment varaible to configure mount location

### DIFF
--- a/fs/tabfs.c
+++ b/fs/tabfs.c
@@ -214,8 +214,7 @@ static struct fuse_operations tabfs_filesystem_operations = {
 int main(int argc, char **argv) {
     char* mountdir = getenv("TABFS_MOUNT_DIR");
     if (mountdir == NULL) {
-        mountdir = malloc(sizeof(char)*4);
-        sprintf(mountdir, "mnt");
+        mountdir = "mnt";
     }
 
     char killcmd[1000];


### PR DESCRIPTION
Adds a check for environment variable `TABFS_MOUNT_DIR` to optionally configure an alternative to the previously hard-coded `mnt` directory.

closes #37  