### PR TITLE
Auto build a dev release with Github Actions

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -1,0 +1,74 @@
+name: Build and release TabFS for Linux
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [15.x]
+
+    steps:
+      - uses: actions/checkout@master
+        with:
+          fetch-depth: 1
+
+      - name: Install libfuse-dev
+        run: sudo apt-get install libfuse-dev
+
+      - name: Compile the FUSE filesystem
+        run: cd fs && make
+
+      - name: Load Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install Web-ext
+        run: npm install --global web-ext
+      
+      - name: Build browser extension
+        run: web-ext build -s extension -n tabfs.zip
+      
+      - name: Create tarball
+        run: tar -cvf tabfs-filesystem.tar fs/tabfs install.sh
+
+      - name: Set git commit hash
+        id: vars
+        run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+
+      - name: Create release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: dev/${{ steps.vars.outputs.sha_short }}
+          release_name: 'Development Release #${{ steps.vars.outputs.sha_short }}'
+          draft: false
+          prerelease: true
+      
+      - name: Upload filesystem asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }} 
+          asset_path: ./tabfs-filesystem.tar
+          asset_name: tabfs-filesystem.tar
+          asset_content_type: application/x-tar
+          
+      - name: Upload browser extension
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./web-ext-artifacts/tabfs.zip
+          asset_name: tabfs-web-extension.zip
+          asset_content_type: application/zip


### PR DESCRIPTION
Hi! I'm not sure if this is something you're interested in, but I thought it could help other try out TabFS faster.

This PR doesn't change any TabFS code. Instead it just adds a GH Action workflow that compiles the filesystem (for Linux only at this point, as I couldn't test it on a mac), and packs the extension using Mozilla's Web-ext. It then creates a "pre-release" holding the two assets - a tar file the one can just untar and run "install.sh", and a zip file the one can load onto Firefox Developer Edition.

It automatically runs after every commit.

I would love to explore how I could improve this to help Chrome / Mac users too, in case someone finds this interesting.