### PR TITLE
read/write textareas

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -439,6 +439,26 @@ router["/tabs/by-id/*/active"] = {
   });
 })();
 
+router["/tabs/by-id/*/textareas"] = {
+  async readdir({path}) {
+    const tabId = parseInt(pathComponent(path, -2));
+    // TODO: assign new IDs to textareas without them?
+    const code = `Array.from(document.querySelectorAll('textarea')).map(e => e.id).filter(id => id)`
+    const ids = (await browser.tabs.executeScript(tabId, {code}))[0];
+    return { entries: [".", "..", ...ids.map(id => `${id}.txt`)] };
+  }
+};
+router["/tabs/by-id/*/textareas/*"] = defineFile(async path => {
+  const [tabId, textareaId] = [parseInt(pathComponent(path, -3)), pathComponent(path, -1).slice(0, -4)];
+  const code = `document.getElementById('${textareaId}').value`;
+  const textareaValue = (await browser.tabs.executeScript(tabId, {code}))[0];
+  return textareaValue;
+}, async (path, buf) => {
+  const [tabId, textareaId] = [parseInt(pathComponent(path, -3)), pathComponent(path, -1).slice(0, -4)];
+  const code = `document.getElementById('${textareaId}').value = unescape('${escape(buf)}')`;
+  await browser.tabs.executeScript(tabId, {code});
+});
+
 router["/tabs/by-title"] = {
   getattr() {
     return {


### PR DESCRIPTION
rudimentary; just getting my feet wet!

inspired by [Anil Dash's feature request](https://anildash.com/2021/01/03/keeping-tabs-on-your-abstractions/).

![submitting a pull request with TabFS](https://user-images.githubusercontent.com/643799/104154725-794b9e80-539a-11eb-93ba-86c8dded03d3.png)
demonstration: https://user-images.githubusercontent.com/643799/104154300-6be1e480-5399-11eb-8f3e-853a8c817f79.mp4.

the thought arose that this should really be done building off a general "dom tree as file tree" adapter, but actually: 1. there isn't anything like `document.querySelectorAll` for file trees, and 2. there's no particularly nice way to make one file tree a computed 'view' on another file tree. so that approach has some obstacles.

(btw: this PR is 99% just to share my exploration – no worries if it doesn't make sense to merge this!)