### PR TITLE
Fix FreeBSD support that broke when multithreading was implemented

### DIFF
--- a/fs/Makefile
+++ b/fs/Makefile
@@ -36,3 +36,4 @@ unmount:
 	killall -9 tabfs || true
 	diskutil unmount force mnt || true
 	fusermount -u mnt || true
+	umount -f mnt || true

--- a/fs/tabfs.c
+++ b/fs/tabfs.c
@@ -479,7 +479,9 @@ int main(int argc, char **argv) {
         argv[0],
         "-f",
 #if !defined(__APPLE__)
+#if !defined(__FreeBSD__)
         "-oauto_unmount",
+#endif
 #endif
         "-odirect_io",
         getenv("TABFS_MOUNT_DIR"),


### PR DESCRIPTION
Current master of tabfs on FreeBSD immediately returns (exit code 1, no output), `ls mnt` gives "Device not configured". The log says "mount_fusefs: -o auto_unmount: option not supported"

Since the auto_unmount option is already guarded with an `#if !defined(__APPLE__)`, I just added another one for FreeBSD, and it seems to work again.
