### PR TITLE
Adding installation support to Microsoft  Edge Dev for Linux

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -8,8 +8,9 @@ if [[ "$#" -lt 1 || (
               ( "$1" == "chrome" && "$#" -eq 2 && ${#2} -eq 32 ) ||
               ( "$1" == "vivaldi" && "$#" -eq 2 && ${#2} -eq 32 ) ||
               ( "$1" == "chromebeta" && "$#" -eq 2 && ${#2} -eq 32 ) ||
-              ( "$1" == "chromium" && "$#" -eq 2 && ${#2} -eq 32 ) ) ) ]]; then
-    echo "Usage: $0 <chrome EXTENSION_ID | chromebeta EXTENSION_ID | chromium EXTENSION_ID | vivaldi EXTENSION_ID | firefox>"
+              ( "$1" == "chromium" && "$#" -eq 2 && ${#2} -eq 32 ) ||
+              ( "$1" == "edgedev" && "$#" -eq 2 && ${#2} -eq 32 ) ) ) ]]; then
+    echo "Usage: $0 <chrome EXTENSION_ID | chromebeta EXTENSION_ID | chromium EXTENSION_ID | vivaldi EXTENSION_ID | edgedev EXTENSION_ID | firefox>"
     exit 2
 fi
     
@@ -33,6 +34,8 @@ case "$OS $BROWSER" in
         MANIFEST_LOCATION="$HOME/.config/chromium/NativeMessagingHosts";;
     "Linux vivaldi")
         MANIFEST_LOCATION="$HOME/.config/vivaldi/NativeMessagingHosts";;
+    "Linux edgedev")
+        MANIFEST_LOCATION="$HOME/.config/microsoft-edge-dev/NativeMessagingHosts";;
     "Darwin chrome")
         MANIFEST_LOCATION="$HOME/Library/Application Support/Google/Chrome/NativeMessagingHosts";;
     "Darwin chromebeta")
@@ -47,7 +50,7 @@ APP_NAME="com.rsnous.tabfs"
 EXE_PATH=$(pwd)/fs/tabfs
 
 case "$BROWSER" in
-    chrome | chromium | chromebeta | vivaldi)
+    chrome | chromium | chromebeta | vivaldi | edgedev)
         EXTENSION_ID=$2
         MANIFEST=$(cat <<EOF
 {


### PR DESCRIPTION
Hello !

I'm just adding support to tthe Linux version of Microsoft Edge Dev for Linux, no big modification, like Vivaldi, they have their own folder in `$HOME/.config`.

I chose the name `edgedev` in the same spirit of the existing occurence of `chromebeta`.

