### PR TITLE
Create CI build workflow for macOS and Linux

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,36 @@
+name: CI
+on:
+  # Trigger for pushes to all branches
+  push:
+  # Triggers the workflow for PRs to the master branch
+  pull_request:
+    branches: [ master ]
+  # Manual trigger from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        include:
+          - os: ubuntu-latest
+            fuse_install_cmd: 'sudo apt-get install libfuse-dev'
+          - os: macos-latest
+            fuse_install_cmd: 'brew update && brew install --cask macfuse'
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install FUSE
+        run: ${{ matrix.fuse_install_cmd }}
+
+      - name: Compile FUSE native messaging host
+        run: cd fs && make
+
+      - name: 'Upload Artifact'
+        uses: actions/upload-artifact@v2
+        with:
+          name: tabfs-${{ matrix.os }}
+          path: fs/tabfs


### PR DESCRIPTION
Hi! Its been awhile since PokeNet... almost a decade now? I noticed your new project and decided to mess with it some.

---

Currently this just builds the TabFS native messaging host binary on macOS and Linux.

The latest version of Homebrew has a cask for fuse 4.0.5, but the macOS build VMs have an older version, so `brew update` is required for now, even though it is slow.

I set it to add the compiled tabfs binary as an artifact, though that could easily be changed to just include the entire build workspace for sanity checking any other output files.

Will need to play some with chrome headless and see if it will work for running the tests -- compiling the test binary also seems to be excessively slow (10+ minutes), so that's another thing that will need sorting out.