### PR TITLE
Add support for Vivaldi on macOS

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -42,6 +42,8 @@ case "$OS $BROWSER" in
         MANIFEST_LOCATION="$HOME/Library/Application Support/Google/Chrome Beta/NativeMessagingHosts";;
     "Darwin chromium")
         MANIFEST_LOCATION="$HOME/Library/Application Support/Chromium/NativeMessagingHosts";;
+    "Darwin vivaldi")
+        MANIFEST_LOCATION="$HOME/Library/Application Support/Vivaldi/NativeMessagingHosts";;
 esac
 
 mkdir -p "$MANIFEST_LOCATION"


### PR DESCRIPTION
I changed `install.sh` to add support for Vivaldi on macOS. (This adds on to #22's efforts.)