### PR TITLE
add windows support through cygwin

### DIFF
--- a/fs/Makefile
+++ b/fs/Makefile
@@ -22,6 +22,10 @@ ifeq ($(shell uname -s),FreeBSD)
 	CFLAGS += -L$(FREEBSD_ROOT)/lib -I$(FREEBSD_ROOT)/include $(CFLAGS_EXTRA)
 	LIBS = -lfuse -pthread
 endif
+ifeq ($(shell uname -o),Cygwin)
+	CFLAGS += $(shell pkg-config --cflags fuse)
+	LIBS = $(shell pkg-config --libs fuse)
+endif
 
 all: $(TARGETS)
 

--- a/test/test.c
+++ b/test/test.c
@@ -9,6 +9,13 @@
 #include <wordexp.h>
 #include <regex.h>
 
+#if defined(__CYGWIN__)
+ // needs to be the native path for file:// urls to work
+ #define PWD "$(cygpath -w \"$(pwd)\")"
+#else
+ #define PWD "$(pwd)"
+#endif
+
 int file_contents_equal(char* path, char* contents) {
     // hehe: https://twitter.com/ianh_/status/1340450349065244675
     setenv("path", path, 1);
@@ -55,7 +62,7 @@ int main() {
     }
 
     {
-        assert(system("echo file://$(pwd)/test-resources/test-page.html > ../fs/mnt/tabs/create") == 0);
+        assert(system("echo file://" PWD "/test-resources/test-page.html > ../fs/mnt/tabs/create") == 0);
         assert(file_contents_equal("../fs/mnt/tabs/last-focused/title.txt", "Title of Test Page"));
         assert(file_contents_equal("../fs/mnt/tabs/last-focused/text.txt", "Body Text of Test Page"));
 
@@ -87,7 +94,7 @@ int main() {
     }
 
     {
-        assert(system("echo file://$(pwd)/test-resources/test-textarea.html > ../fs/mnt/tabs/create") == 0);
+        assert(system("echo file://" PWD "/test-resources/test-textarea.html > ../fs/mnt/tabs/create") == 0);
         {
             assert(system("echo \"document.getElementById('ta').value\" > ../fs/mnt/tabs/last-focused/evals/ta.js") == 0);
 

--- a/test/test.js
+++ b/test/test.js
@@ -15,7 +15,7 @@ const {Routes, tryMatchRoute} = require('../extension/background');
                    { entries: ['.', '..', 'windows', 'extensions', 'tabs', 'runtime'] });
   assert.deepEqual(await Routes['/tabs'].readdir(),
                    { entries: ['.', '..', 'create',
-                               'by-id', 'by-title', 'last-focused'] });
+                               'by-title', 'last-focused', 'by-id'] });
 
   assert.deepEqual(tryMatchRoute('/'), [Routes['/'], {}]);
 


### PR DESCRIPTION
using [winfsp](https://github.com/billziss-gh/winfsp)'s "fuse for cygwin" component

i've tested this on windows 8.1 with chromium and most things seem to work. even the tests in `test/` pass

known limitations:

- symlinks in `/tabs/by-title/` show up as inaccessible files in explorer.exe (but they work in cygwin)
- windows photo viewer doesn't like loading the `tab.png` images from tabfs (copying them out first works)

prerequisites and steps for building:

- cygwin - https://cygwin.com/install.html
- winfsp - http://www.secfs.net/winfsp/rel/

1. install cygwin and at select least these packages: `gcc-core`, `git`, `make`, and everything in the `base` group
2. install winfsp and select `FUSE for Cygwin` in the installer
3. open a cygwin terminal
4. run the `install.sh` script from the winfsp install directory - probably `bash "/cygdrive/c/Program Files (x86)/WinFsp/opt/cygfuse/install.sh"`
5. (at this step: git clone, build and install tabfs like you would on other systems)
   ```bash
   git clone https://github.com/osnr/TabFS --depth=1 && cd TabFS
   cd fs/ && make && cd ..
   # run "bash install.sh" manually
   ```
6. copy the libraries used by `tabfs.exe` to the same directory: `cp -t ./fs/ /bin/cygwin1.dll /bin/cygfuse-2.8.dll` - otherwise it'll fail to load them when it's launched by the browser
   (btw, you can list what libraries an .exe or .dll uses by doing `ldd tabfs.exe` in cygwin. note that the listing isn't recursive so you might have to run it on the .dlls too for a complete list)
7. that's it. reload the extension and go look at the filesystem in `C:\cygwin64\home\you\TabFS\fs\mnt\` (path may vary)

random notes:

- the process of loading the manifest for the native extension host is a bit different on windows - the location of the `.json` file doesn't matter but there must be a registry key pointing to it
- `winfsp-fuse` expects that the mount directory doesn't already exist and will fail if it does
- it's possible to set `TABFS_MOUNT_DIR` using windows' [thing for setting environment variables](https://www.wikihow.com/Create-an-Environment-Variable-in-Windows-10) - it can be either a cygwin path (like `/home/you/tabfs` for your home directory inside the cygwin root) or a native one (like `C:\Users\you\Desktop\tabfs` for the windows desktop)
- i didn't test this but `step 6` might be avoidable if you add `C:\cygwin64\bin` to the `PATH` environment variable so it's searched when loading the .dlls
- the resulting `tabfs.exe` with the .dlls might work on systems without cygwin (but i haven't tested it) - but if it's going to be distributed like that, then `install.sh` would also need a replacement that doesn't require bash
